### PR TITLE
Patel/15 info sub accessh2o

### DIFF
--- a/src/screens/AccessH2OView/InfoSubmission/InfoSubmissionPage.module.css
+++ b/src/screens/AccessH2OView/InfoSubmission/InfoSubmissionPage.module.css
@@ -17,6 +17,10 @@
     text-align: right;
 }
 
+.applicantStatus > h4 {
+    display: inline;
+}
+
 .statusButton {
     width: 126px;
 }

--- a/src/screens/AccessH2OView/InfoSubmission/InfoSubmissionPage.module.css
+++ b/src/screens/AccessH2OView/InfoSubmission/InfoSubmissionPage.module.css
@@ -1,0 +1,36 @@
+.root {
+    margin-left: 50px;
+}
+.applicant {
+    display: flex;
+    flex-direction: column;
+    margin-right: 50%;
+}
+
+.applicantInfo > h4 {
+    display: inline;
+    padding-right: 10px;
+}
+
+.applicantInfo > p {
+    display: inline;
+    text-align: right;
+}
+
+.statusButton {
+    width: 126px;
+}
+
+.comments {
+    display: flex;
+    flex-direction: column;
+}
+
+.commentBox {
+    padding: 10px;
+    margin-bottom: 15px;
+}
+
+.commentSubmit {
+    width: 126px;
+}

--- a/src/screens/AccessH2OView/InfoSubmission/InfoSubmissionPage.tsx
+++ b/src/screens/AccessH2OView/InfoSubmission/InfoSubmissionPage.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from "react";
+import { Applicant, ApplicantStatus } from "../../../types/Applicant";
+import classes from "./InfoSubmissionPage.module.css"
+
+type infoSubmission = {
+  payments: string,
+  minimumService: string,
+  customerContact: string,
+  waterMeter: string,
+  paymentHistory: string,
+  usageHistory: string,
+  pendingAdjustments: string,
+  individualsInvolved: string,
+  additionalInformation: string
+}
+
+const dummyApplicant: Applicant = {
+  name: "applicant 1",
+  utilityCompany: "City of Atlanta",
+  accountId: "123456789",
+  propertyAddress: "123 George Burdell Blvd",
+  applied: new Date(),
+  status: ApplicantStatus.AwaitingAccessH2OAction,
+}
+
+const dummyInfoSub: infoSubmission = {
+  payments: "Yes",
+  minimumService: "No",
+  customerContact: "Yes",
+  waterMeter: "Yes",
+  paymentHistory: "dummydoc.pdf",
+  usageHistory: "dummydoc.pdf",
+  pendingAdjustments: "We have a number of concerns",
+  individualsInvolved: "spouse, lanlord, and children",
+  additionalInformation: "No"
+}
+
+const InfoSubmissionPage = () => {
+
+  const [applicant, setApplicant] = useState(dummyApplicant)
+  const [infoSub, setInfoSub] = useState(dummyInfoSub)
+  const [comments, setComments] = useState("")
+
+  // TODO fetch applicant data based on applicantId
+  // TODO fetch information submission based on applicantId?
+  // TODO save comments somewhere
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.applicant}>
+        <h2>{applicant.name}</h2>
+        <div className={classes.applicantInfo}>
+          <h4>Utility</h4>
+          <p>{applicant.utilityCompany}</p>
+        </div>
+        <div className={classes.applicantInfo}>
+          <h4>Account Id</h4>
+          <p>{applicant.accountId}</p>
+        </div>
+        <div className={classes.applicantInfo}>
+          <h4>Property Address</h4>
+          <p>{applicant.propertyAddress}</p>
+        </div>
+        <div className={classes.applicantInfo}>
+          <h4>Status</h4>
+          <p>{applicant.status}</p>
+          <button>Change Status</button>
+        </div>
+        <button className={classes.statusButton}>Update Applicant</button>
+      </div>
+
+      <div className={classes.eligibility}>
+        <h3>Eligibility</h3>
+        <h4>Has the customer made at least 3 payments?</h4>
+        <p>{infoSub.payments}</p>
+        <h4>Does the customer have a minimum of 12 months of service?</h4>
+        <p>{infoSub.minimumService}</p>
+        <h4>Has the customer been in contact with your utility company?</h4>
+        <p>{infoSub.customerContact}</p>
+        <h4>Does the property with dedicated water meter?</h4>
+        <p>{infoSub.waterMeter}</p>
+      </div>
+
+      <div className={classes.document}>
+        <h3>Document Submission</h3>
+        <h4>Payment History</h4>
+        <h4>Usuage History</h4>
+      </div>
+
+      <div className={classes.other}>
+        <h3>Other</h3>
+        <h4>Are there any pending adjustments?</h4>
+        <p>{infoSub.pendingAdjustments}</p>
+        <h4>What (if any) other individuals are involved (spouse, landlord, dependents)?</h4>
+        <p>{infoSub.individualsInvolved}</p>
+        <h4>Is there any additional information we should know about the account?</h4>
+        <p>{infoSub.additionalInformation}</p>
+      </div>
+
+      <div className={classes.comments}>
+        <h3>Request Additional Information</h3>
+        <textarea
+          className={classes.commentBox} 
+          placeholder="Request additional information from utility companies"
+          value={comments}
+          onChange={(event) => setComments(event.target.value)}
+          rows={10}
+        />
+        <button className={classes.commentSubmit}>Submit</button>
+      </div>
+    </div>
+  );
+}
+
+export default InfoSubmissionPage;

--- a/src/screens/AccessH2OView/InfoSubmission/InfoSubmissionPage.tsx
+++ b/src/screens/AccessH2OView/InfoSubmission/InfoSubmissionPage.tsx
@@ -39,11 +39,16 @@ const InfoSubmissionPage = () => {
 
   const [applicant, setApplicant] = useState(dummyApplicant)
   const [infoSub, setInfoSub] = useState(dummyInfoSub)
+  const [applicantStatus, setApplicantStatus] = useState(dummyApplicant.status)
   const [comments, setComments] = useState("")
 
   // TODO fetch applicant data based on applicantId
   // TODO fetch information submission based on applicantId?
   // TODO save comments somewhere
+
+  const updateStatus = (event) => {
+    setApplicantStatus(event.target.value)
+  }
 
   return (
     <div className={classes.root}>
@@ -61,10 +66,15 @@ const InfoSubmissionPage = () => {
           <h4>Property Address</h4>
           <p>{applicant.propertyAddress}</p>
         </div>
-        <div className={classes.applicantInfo}>
-          <h4>Status</h4>
-          <p>{applicant.status}</p>
-          <button>Change Status</button>
+        <div className={classes.applicantStatus}>
+          <h4>Applicant Status</h4>
+          <input type="radio" value={ApplicantStatus.Incomplete} checked={applicantStatus == ApplicantStatus.Incomplete} onChange={updateStatus} /> Incomplete
+          <input type="radio" value={ApplicantStatus.AwaitingUtilityAction} checked={applicantStatus == ApplicantStatus.AwaitingUtilityAction} onChange={updateStatus} /> AwaitingUtilityAction
+          <input type="radio" value={ApplicantStatus.AwaitingAccessH2OAction} checked={applicantStatus == ApplicantStatus.AwaitingAccessH2OAction} onChange={updateStatus} /> AwaitingAccessH2OAction
+          <input type="radio" value={ApplicantStatus.Approved} checked={applicantStatus == ApplicantStatus.Approved} onChange={updateStatus} /> Approved
+          <input type="radio" value={ApplicantStatus.Completed} checked={applicantStatus == ApplicantStatus.Completed} onChange={updateStatus} /> Completed
+          <input type="radio" value={ApplicantStatus.Denied} checked={applicantStatus == ApplicantStatus.Denied } onChange={updateStatus} /> Denied
+          <input type="radio" value={ApplicantStatus.Terminated} checked={applicantStatus == ApplicantStatus.Terminated} onChange={updateStatus}/> Terminated
         </div>
         <button className={classes.statusButton}>Update Applicant</button>
       </div>

--- a/src/screens/AccessH2OView/InfoSubmission/index.tsx
+++ b/src/screens/AccessH2OView/InfoSubmission/index.tsx
@@ -1,0 +1,3 @@
+import InfoSubmissionPage from "./InfoSubmissionPage";
+
+export default InfoSubmissionPage;


### PR DESCRIPTION
## Info Submission: AccessH2O View
Creates a page for AccessH2O members to view information submitted by utility companies. All of the data is non-editable except the status of the applicant and additional comments that the AccessH2O member would like to send to the utility companies
- Viewing submitted documents is incomplete and design needs to be updated

### Important Changes

- AccessH2O page for unedited submitted applicant info
- Button exists to change applicant status (does not actually update applicant)
- Comment section with submit button to request additional information

### Related Github Issues

- #15 
