### PR TITLE
Account creation  button and logic

### DIFF
--- a/server/mongodb/models/User.ts
+++ b/server/mongodb/models/User.ts
@@ -13,6 +13,14 @@ const UserSchema = new Schema({
     type: String,
     required: true,
   },
+  isUtilityCompany: {
+    type: Boolean,
+    required: true,
+  },
+  utilityCompany: {
+    type: String,
+    required: false,
+  },
 });
 
 export default mongoose.models.User ?? mongoose.model("User", UserSchema);

--- a/src/components/AccountCreationModal/AccountCreationModal.module.css
+++ b/src/components/AccountCreationModal/AccountCreationModal.module.css
@@ -1,0 +1,47 @@
+.modal {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+.modalwrapper {
+    box-sizing: border-box;
+    background: white;
+    border-radius: 10px;;
+    max-width: 480px;
+    justify-content: space-between;
+    padding: 15px 37px 25px 37px;
+    font-family: sans-serif;
+}
+
+.modalheader {
+    background:white;
+    color: black;
+    display: flex;
+    justify-content: space-between;
+}
+
+.modalcontent {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px;
+} 
+
+.modalInput {
+    margin-bottom: 10px;
+    width: 280px;
+}
+
+.closemodalbtn {
+    font-family: sans-serif;
+    font-size: 40px;
+    cursor: pointer;
+    color:grey;
+}
+
+.modalfooter {
+    display: flex;
+    justify-content: flex-end;
+}

--- a/src/components/AccountCreationModal/AccountCreationModal.tsx
+++ b/src/components/AccountCreationModal/AccountCreationModal.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react'
+import Button from '@material-ui/core/Button'
+import classes from './AccountCreationModal.module.css'
+import TextField from '@material-ui/core/TextField'
+import Modal from '@mui/material/Modal'
+import PropTypes from 'prop-types'
+import { Visibility, VisibilityOff } from '@material-ui/icons'
+import { IconButton, InputAdornment } from '@material-ui/core'
+
+interface PropTypes {
+  shouldShowModal: boolean
+  onClose: () => void
+}
+
+export const AccountCreationModal = ({ shouldShowModal, onClose }: PropTypes): JSX.Element => {
+  const [values, setValues] = React.useState({
+    password: '',
+    showPassword: false,
+  });
+
+  const handleClickShowPassword = () => {
+    setValues({
+      ...values,
+      showPassword: !values.showPassword,
+    });
+  };
+
+  const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <div>
+      <Modal open={shouldShowModal} onClose={onClose} className={classes.modal}>
+        <div className={classes.modalwrapper}>
+          <div className={classes.modalheader}>
+            <h3>Account Creation</h3>
+            <span onClick={onClose} className={classes.closemodalbtn}>
+              &times;
+            </span>
+          </div>
+          <div className={classes.modalcontent}>
+            <TextField
+              id="email"
+              label="Email"
+              variant="outlined"
+              size="small"
+              InputProps={{className: classes.modalInput}}
+            />
+            <TextField
+              id="utility-company"
+              label="Utility Company"
+              variant="outlined"
+              size="small"
+              InputProps={{className: classes.modalInput}}
+            />
+            <TextField
+              id="password"
+              label="Password"
+              type={values.showPassword ? 'text' : 'password'}
+              variant="outlined"
+              size="small"
+              InputProps={{
+                className: classes.modalInput,
+                endAdornment: <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle password visibility"
+                    onClick={handleClickShowPassword}
+                    onMouseDown={handleMouseDownPassword}
+                    edge="end"
+                  >
+                    {values.showPassword ? <VisibilityOff /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              }}
+            />
+          </div>
+          <div className={classes.modalfooter}>
+            <Button onClick={onClose} className={classes.submit} style={{backgroundColor: "#4DBAEA"}}>
+              Submit
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  )
+}

--- a/src/components/AccountCreationModal/index.tsx
+++ b/src/components/AccountCreationModal/index.tsx
@@ -1,0 +1,3 @@
+import { AccountCreationModal } from "./AccountCreationModal";
+
+export default AccountCreationModal;

--- a/src/components/ApplicantTable/ApplicantTable.module.css
+++ b/src/components/ApplicantTable/ApplicantTable.module.css
@@ -1,5 +1,5 @@
 .root {
-    margin: 0px 50px 0px 50px;
+    margin: 0px 50px 50px 50px;
     background: rgba(196, 196, 196, 0.2);
     border-radius: 8px;
 }

--- a/src/screens/AccessH2OView/ApplicantView/ApplicantView.module.css
+++ b/src/screens/AccessH2OView/ApplicantView/ApplicantView.module.css
@@ -1,0 +1,10 @@
+.header {
+    margin: 48px 0px 45px 55px;
+    font-family: Arial, serif;
+}
+
+.accountModal {
+    display: flex;
+    justify-content: flex-end;
+    margin: 30px 45px 0px 0px;
+}

--- a/src/screens/AccessH2OView/ApplicantView/ApplicantViewPage.tsx
+++ b/src/screens/AccessH2OView/ApplicantView/ApplicantViewPage.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react'
+import ApplicantTable from '../../../components/ApplicantTable'
+import classes from './ApplicantView.module.css'
+import urls from '../../../../utils/urls'
+import AccountCreationModal from '../../../components/AccountCreationModal'
+import { Button } from '@material-ui/core'
+
+
+const ApplicantViewPage = (): JSX.Element => {
+  const [showModal, setShowModal] = useState(false)
+
+  const closeModalHandler = (): void => setShowModal(false)
+  return (
+    <>
+      <div  className={classes.accountModal}>
+        <Button onClick={() => setShowModal(true)}>Account Creation</Button>
+        <AccountCreationModal shouldShowModal={showModal} onClose={closeModalHandler}/>
+      </div>
+      <h1 className={classes.header}>Dashboard</h1>
+      <ApplicantTable
+        isUtilityView={false}
+        infoSubmissionEndpoint={urls.pages.infosubmit}
+      />
+    </>
+  )
+}
+
+export default ApplicantViewPage

--- a/src/screens/AccessH2OView/ApplicantView/index.jsx
+++ b/src/screens/AccessH2OView/ApplicantView/index.jsx
@@ -1,0 +1,3 @@
+import ApplicantViewPage from './ApplicantViewPage'
+
+export default ApplicantViewPage

--- a/src/screens/ApplicantView/ApplicantViewPage.tsx
+++ b/src/screens/ApplicantView/ApplicantViewPage.tsx
@@ -8,7 +8,7 @@ const ApplicantViewPage = (): JSX.Element => {
     <>
       <h1 className={classes.header}>Dashboard</h1>
       <ApplicantTable
-        isUtilityView={false}
+        isUtilityView={true}
         infoSubmissionEndpoint={urls.pages.infosubmit}
       />
     </>


### PR DESCRIPTION
## Account Creation Button and Logic

Creates the Account creation button in the AccessH2O view of ApplicantView and updates the signup and login actions for a User model

### Important Changes

- Account creation modal with email, password, and utility company name
- password is hidden
- added the AccessH20 page of ApplicantView and put the account creation button here (official header as in Figma still needs to be added)
- User model now has isUtilityCompany (required) and utilityCompany (not required) as fields to account for types of users
- signup and login actions now consider if a user is a utilityCompany and takes appropriate action

### Related Github Issues

- #43 
