### PR TITLE
Patel/notes modal

### DIFF
--- a/server/models/Note.ts
+++ b/server/models/Note.ts
@@ -1,0 +1,6 @@
+export interface Note {
+    sender: string,
+    receiver: string,
+    date: Date,
+    message: string
+}

--- a/server/mongodb/actions/Client.ts
+++ b/server/mongodb/actions/Client.ts
@@ -14,6 +14,12 @@ export async function getClient(accountId: Client["accountId"]) {
     return client;
 }
 
+export async function getClients() {
+    await mongoDB();
+    const client = await ClientSchema.find();
+    return client;
+}
+
 export async function editNotes(notes: Client["notes"], accountId: Client["accountId"]) {
     await mongoDB();
     const client = await ClientSchema.findOne({ accountId });

--- a/server/mongodb/actions/Note.ts
+++ b/server/mongodb/actions/Note.ts
@@ -1,0 +1,14 @@
+import NoteSchema from "../models/Note";
+import { Note } from "../../models/Note"
+import mongoDB from "../index";
+
+export async function addNote(note: Note) {
+    await mongoDB();
+    return await NoteSchema.create(note);
+}
+
+export async function getNotes() {
+    await mongoDB();
+    const client = await NoteSchema.find();
+    return client;
+}

--- a/server/mongodb/models/Note.ts
+++ b/server/mongodb/models/Note.ts
@@ -1,0 +1,24 @@
+import mongoose, { Types } from "mongoose";
+
+const { Schema } = mongoose;
+
+const NoteSchema = new Schema({
+  sender: {
+    type: String,
+    required: true,
+  },
+  receiver: {
+    type: String,
+    required: true,
+  },
+  date: {
+    type: Date,
+    required: true,
+  },
+  message: {
+    type: String,
+    required: true,
+  },
+});
+
+export default mongoose.models.Note ?? mongoose.model("Note", NoteSchema);

--- a/src/components/ApplicantTable/ApplicantTable.tsx
+++ b/src/components/ApplicantTable/ApplicantTable.tsx
@@ -20,6 +20,7 @@ import { Applicant, ApplicantStatus, ApplicantStatusColor } from '../../types/Ap
 import { ApplicantModal } from 'src/components/ApplicantModal/ApplicantModal'
 import { CompanyModal } from "src/components/CompanyModal/CompanyModal";
 import classes from './ApplicantTable.module.css'
+import { NotesModal } from '../NotesModal/NotesModal'
 
 interface PropTypes {
   isUtilityView: boolean // true = utility view & false = AccessH2O view
@@ -204,6 +205,7 @@ const ApplicantTable = ({
 
   const [showApplicantModal, setShowApplicantModal] = useState(false)
   const [showCompanyModal, setShowCompanyModal] = useState(false)
+  const [showNotesModal, setShowNotesModal] = useState(false)
 
   const statusColor = (status: ApplicantStatus): string => {
     return ApplicantStatusColor[status]
@@ -358,7 +360,9 @@ const ApplicantTable = ({
                         </TableCell>
                         <TableCell align="center">
                         <Tooltip title={'View notes'}>
-                          <IconButton>
+                          <IconButton
+                            onClick={() => setShowNotesModal(true)} 
+                          >
                             <Announcement/>
                           </IconButton>
                         </Tooltip>
@@ -383,7 +387,7 @@ const ApplicantTable = ({
                           }}
                         >
                           <MenuItem onClick={handleClose}>View</MenuItem>
-                          <MenuItem onClick={handleClose}>Add Notes</MenuItem>
+                          <MenuItem onClick={() => setShowNotesModal(true)}>Add Notes</MenuItem>
                           <MenuItem onClick={handleClose}>Change Status</MenuItem>
                           <div className={classes.deleteButton}>
                             <MenuItem onClick={handleClose}>Delete</MenuItem>
@@ -397,7 +401,7 @@ const ApplicantTable = ({
             }
           </TableBody>
         </Table>
-
+        <NotesModal shouldShowModal={showNotesModal} onClose={() => setShowNotesModal(false)} />
         <TablePagination
           count={applicants.length}
           rowsPerPage={rowsPerPage}

--- a/src/components/NotesModal/NotesModal.module.css
+++ b/src/components/NotesModal/NotesModal.module.css
@@ -1,0 +1,39 @@
+.modalwrapper {
+    box-sizing: border-box;
+    background: white;
+    border-radius: 10px;;
+    width: 90%;
+    max-width: 780px;
+    height: auto;
+    margin: 4rem auto;
+    justify-content: center;
+    padding: 20px;
+    font-family:'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
+}
+
+.modalheader {
+    background:white;
+    color: black;
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: -30px;
+    margin-top:-20px;
+}
+
+.closemodalbtn {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 60px;
+    margin-right: 40px;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    color:grey;
+}
+
+.modalcontent {
+    padding: 1rem;
+    align-items: center;
+    justify-content: space-between;
+}

--- a/src/components/NotesModal/NotesModal.module.css
+++ b/src/components/NotesModal/NotesModal.module.css
@@ -2,8 +2,7 @@
     box-sizing: border-box;
     background: white;
     border-radius: 10px;;
-    width: 90%;
-    max-width: 780px;
+    width: 40%;
     height: auto;
     margin: 4rem auto;
     justify-content: center;
@@ -16,7 +15,6 @@
     color: black;
     padding: 1rem;
     display: flex;
-    align-items: center;
     justify-content: space-between;
     margin-bottom: -30px;
     margin-top:-20px;
@@ -25,7 +23,6 @@
 .closemodalbtn {
     font-family: Arial, Helvetica, sans-serif;
     font-size: 60px;
-    margin-right: 40px;
     border: none;
     outline: none;
     cursor: pointer;
@@ -34,6 +31,76 @@
 
 .modalcontent {
     padding: 1rem;
-    align-items: center;
+    align-content: center;
     justify-content: space-between;
+}
+
+.noteHeader {
+    display: flex;
+    flex-direction: row;
+}
+
+.sender {
+    color: #3F78B5;
+    font-size: 14px;
+    font-weight: 600;
+    margin-right: 9px;
+}
+
+.date {
+    color: #979797;
+    font-style: italic;
+    font-size: 14px;
+}
+
+.message {
+    font-size: 14px;
+    margin-top: -4px;
+}
+
+.newNoteContainer {
+    margin-top: 10px;
+}
+
+.addNoteButtons {
+    margin: 10px 0px 30px 0px;
+}
+
+.saveNote {
+    background: #3F78B5;
+    border-radius: 8px;
+    border-color: transparent;
+    width: 105px;
+    height: 33px;
+    color: white;
+    font-weight: 400;
+    margin-right: 10px;
+}
+
+.cancel {
+    background-color: transparent;
+    border: transparent;
+    color: #9A9A9A;
+}
+
+.plusNote {
+    background: transparent;
+    border: transparent;
+    color: #4DBAEA;
+    font-weight: 500;
+    margin: 20px 0px 30px 0px;
+}
+
+.customer {
+    display: flex;
+    justify-content: end;
+}
+
+.customerButton {
+    text-decoration: none;
+    color: white;
+    background: #3F78B5;
+    border-radius: 8px;
+    padding: 8px 20px 8px 20px;
+    font-weight: 400;
 }

--- a/src/components/NotesModal/NotesModal.tsx
+++ b/src/components/NotesModal/NotesModal.tsx
@@ -1,25 +1,58 @@
 import * as React from "react";
-import Button from "@material-ui/core/Button";
 import classes from "./NotesModal.module.css";
 import TextField from "@material-ui/core/TextField";
+import { Divider } from '@mui/material';
+import { v4 as uuidv4 } from 'uuid'
 import Modal from "@mui/material/Modal";
 import PropTypes from "prop-types";
-import Box from '@mui/material/Box';
 import { useEffect, useState } from "react";
-import { getNotes } from '../../../server/mongodb/actions/Note'
+import { getNotes } from 'server/mongodb/actions/Note'
+import { Link } from "@mui/material";
+import urls from "utils/urls";
+import { Note } from "server/models/Note"
+
 
 interface PropTypes {
   shouldShowModal: boolean
   onClose: () => void
 }
 
+const starterNote: Note[] = [
+  {
+    sender: "AccessH20",
+    receiver: "Utility",
+    date: new Date("02/03/2022"),
+    message: "First Note"
+  }
+]
 export const NotesModal = ({ shouldShowModal, onClose }: PropTypes): JSX.Element => {
-  const [notes, setNotes] = useState();
+  const [notes, setNotes] = useState(starterNote);
+  const [newNote, setNewNote] = useState("")
+  const [showAdd, setShowAdd] = useState(false);
 
-  useEffect(() => {
-    const messages = getNotes()
-    console.log(messages)
-  })
+  // TODO utilize mongodb action getNotes()
+  // useEffect(() => {
+  //   const messages = getNotes()
+  //   console.log(messages)
+  //   setNotes(notes)
+  // })
+  
+  const handleTextChange = (e) => {
+    setNewNote(e.target.value)
+  }
+
+  const addNote = () => {
+    // TODO: utilize mongodb action addNote()
+    const dummyDate: Note[] = [{
+      sender: "Utility",
+      receiver: "AccessH20",
+      date: new Date(),
+      message: newNote
+    }]
+    setShowAdd(false)
+    setNotes(notes.concat(dummyDate))
+    setNewNote("")
+  }
   
   return (
     <div>
@@ -27,25 +60,47 @@ export const NotesModal = ({ shouldShowModal, onClose }: PropTypes): JSX.Element
         <Modal open={shouldShowModal} onClose={onClose}>
           <div className={classes.modalwrapper}>
             <div className={classes.modalheader}>
-              <h3 className={classes.addcustomer}>Notes</h3>
+              <h3>Notes</h3>
               <span onClick={onClose} className={classes.closemodalbtn}>
                 &#10799;
               </span>
             </div>
-            <Box
-              className={classes.modalcontent}
-              component="form"
-              sx={{
-                '& .MuiTextField-root': { m: 1, width: '32ch' },
-              }}
-              noValidate
-              autoComplete="off"
-            >
+            <div className={classes.modalcontent}>
+            <Divider />
+              {notes.map((note) => (
+                <div>
+                  <div className={classes.noteHeader}>
+                    <p className={classes.sender}>{note.sender}</p>
+                    <p className={classes.date}>{note.date.getMonth()}/{note.date.getDate()}/{note.date.getFullYear()}</p>
+                  </div>
+                  <p className={classes.message}>{note.message}</p>
+                  <Divider />
+                </div>
+              ))}
 
-                <Button>+ Add Note</Button>
-
-                <Button>View Customer Info</Button>
-            </Box>
+              {showAdd ? 
+                <div>
+                  <div className={classes.newNoteContainer}>
+                    <TextField
+                    value={newNote}
+                    onChange={handleTextChange}
+                    variant="outlined"
+                    multiline
+                    fullWidth
+                    minRows={2} />
+                  </div>
+                  <div className={classes.addNoteButtons}>
+                    <button className = {classes.saveNote} onClick={addNote}>Add Note</button>
+                    <button onClick = {() => setShowAdd(false)} className={classes.cancel}>Cancel</button>
+                  </div>
+                </div> :
+                <button onClick = {() => setShowAdd(true)} className={classes.plusNote}>+ Add Note</button>
+              }
+              {/* TODO: Once table & infoSubmit are linked to backend, change link to match correct customer info */}
+              <div className={classes.customer}>
+                <Link href={urls.pages.infosubmit + '/' + uuidv4().toString()} className={classes.customerButton}>View Customer Info</Link>
+              </div>
+            </div>
           </div>
         </Modal>
       </div>

--- a/src/components/NotesModal/NotesModal.tsx
+++ b/src/components/NotesModal/NotesModal.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import Button from "@material-ui/core/Button";
+import classes from "./NotesModal.module.css";
+import TextField from "@material-ui/core/TextField";
+import Modal from "@mui/material/Modal";
+import PropTypes from "prop-types";
+import Box from '@mui/material/Box';
+import { useEffect, useState } from "react";
+import { getNotes } from '../../../server/mongodb/actions/Note'
+
+interface PropTypes {
+  shouldShowModal: boolean
+  onClose: () => void
+}
+
+export const NotesModal = ({ shouldShowModal, onClose }: PropTypes): JSX.Element => {
+  const [notes, setNotes] = useState();
+
+  useEffect(() => {
+    const messages = getNotes()
+    console.log(messages)
+  })
+  
+  return (
+    <div>
+      <div>
+        <Modal open={shouldShowModal} onClose={onClose}>
+          <div className={classes.modalwrapper}>
+            <div className={classes.modalheader}>
+              <h3 className={classes.addcustomer}>Notes</h3>
+              <span onClick={onClose} className={classes.closemodalbtn}>
+                &#10799;
+              </span>
+            </div>
+            <Box
+              className={classes.modalcontent}
+              component="form"
+              sx={{
+                '& .MuiTextField-root': { m: 1, width: '32ch' },
+              }}
+              noValidate
+              autoComplete="off"
+            >
+
+                <Button>+ Add Note</Button>
+
+                <Button>View Customer Info</Button>
+            </Box>
+          </div>
+        </Modal>
+      </div>
+    </div>
+  )
+}

--- a/src/components/NotesModal/index.tsx
+++ b/src/components/NotesModal/index.tsx
@@ -1,0 +1,3 @@
+import { NotesModal } from "./NotesModal";
+
+export default NotesModal;


### PR DESCRIPTION
## Create a Notes Modal
I finished the notes modal as much as I can without the backend. 

When the modal is opened, it displays all the existing notes. When '+ add note' is clicked, a text box, 'add note' button, and 'cancel' button pop up. Currently, when 'add note' is hit, it just adds the note to the state. 

I added comments of where the backend implementation should be added, but the application table also needs to be connected so the sender/receiver can extracted too.

### Important Changes

- notes (text & timestamp)
- add note button (adds to dummy data)
- button to go to applicant view (currently only one applicant view)

### Related Github Issues

- #40 

