### PR TITLE
added linking for applicant table

### DIFF
--- a/src/components/ApplicantTable/ApplicantTable.tsx
+++ b/src/components/ApplicantTable/ApplicantTable.tsx
@@ -258,19 +258,49 @@ const ApplicantTable = ({
                           {applicant.name}
                         </TableCell>
                       </Link>
-                      <TableCell className={classes.cell}>{applicant.utilityCompany}</TableCell>
-                      <TableCell className={classes.cell}>{applicant.accountId}</TableCell>
-                      <TableCell className={classes.cell}>
-                        {applicant.propertyAddress}
-                      </TableCell>
-                      <TableCell className={classes.cell}>
+                      <Link
+                        href={
+                          infoSubmissionEndpoint + '/' + applicant.accountId
+                        }
+                      >
+                        <TableCell className={classes.cell}>{applicant.utilityCompany}</TableCell>
+                      </Link>
+                      <Link
+                        href={
+                          infoSubmissionEndpoint + '/' + applicant.accountId
+                        }
+                      >
+                        <TableCell className={classes.cell}>{applicant.accountId}</TableCell>
+                      </Link>
+                      <Link
+                        href={
+                          infoSubmissionEndpoint + '/' + applicant.accountId
+                        }
+                      >
+                        <TableCell className={classes.cell}>
+                          {applicant.propertyAddress}
+                        </TableCell>
+                      </Link>
+                      <Link
+                        href={
+                          infoSubmissionEndpoint + '/' + applicant.accountId
+                        }
+                      >
+                        <TableCell className={classes.cell}>
                         {new Date(applicant.applied).toDateString()}
                       </TableCell>
-                      <TableCell className={classes.cell}>
-                        <span className={classes.status} style={{ backgroundColor: statusColor(applicant.status) }}>
-                          {applicant.status}
-                        </span>
-                      </TableCell>
+                      </Link>
+                      <Link
+                        href={
+                          infoSubmissionEndpoint + '/' + applicant.accountId
+                        }
+                      >
+                        <TableCell className={classes.cell}>
+                          <span className={classes.status} style={{ backgroundColor: statusColor(applicant.status) }}>
+                            {applicant.status}
+                          </span>
+                        </TableCell>
+                      </Link>
                       <TableCell align="center">
                       <Tooltip title={'View notes'}>
                         <IconButton


### PR DESCRIPTION
## Make Whole Row Clickable

Right now you can only click on the applicant name to get to the info submission page. This edit allows a user to click anywhere on the row to get to infosubmit

### Related Github Issues

- #106 