### PR TITLE
Charlie/document upload download

### DIFF
--- a/server/models/DocumentQuestion.ts
+++ b/server/models/DocumentQuestion.ts
@@ -8,5 +8,5 @@ export interface documentQuestion {
 
 export interface documentQA {
   question: documentQuestion
-  answer: string
+  answer: Buffer
 }

--- a/server/mongodb/models/InfoSubmission.js
+++ b/server/mongodb/models/InfoSubmission.js
@@ -24,7 +24,7 @@ const InfoSubmissionSchema = new Schema({
           title: String,
           description: String
         },
-        answer: String
+        answer: Buffer
       }
     ],
     required: false

--- a/src/components/ApplicantModal/ApplicantModal.tsx
+++ b/src/components/ApplicantModal/ApplicantModal.tsx
@@ -82,7 +82,7 @@ export const ApplicantModal = ({ shouldShowModal, onClose }: PropTypes): JSX.Ele
     const documentQuestionAnswer: documentQA[] = documentQuestions.map((question: documentQuestion) => {
       return {
         question: question,
-        answer: ''
+        answer: Buffer.from('')
       }
     })
 

--- a/src/screens/InfoSubmission/InfoSubmissionPage.tsx
+++ b/src/screens/InfoSubmission/InfoSubmissionPage.tsx
@@ -87,6 +87,7 @@ const InfoSubmissionPage = ({ applicantId }: PropTypes): JSX.Element => {
     setEligibilityQuestions(info.eligibilityQuestions)
     setDocumentQuestions(info.documents)
     setOtherQuestions(info.otherQuestions)
+    console.log(info.documents[0].answer)
   }
 
   const getEmptyBoxes = (): void => {
@@ -114,17 +115,33 @@ const InfoSubmissionPage = ({ applicantId }: PropTypes): JSX.Element => {
     const reader = new FileReader()
     reader.readAsDataURL(file.target.files[0])
     reader.onload = () => {
-      const f = reader.result as Buffer
+      console.log(reader.result)
+      if (reader.result !== null) {
+        const f = Buffer.from((reader.result as string).split(',')[1], 'base64')
+        console.log(f.toString('base64'))
+        /*
+        const blob = new Blob([f], { type: 'application/pdf' })
 
-      duplicate[index].answer = f
-      const emptyDuplicate = emptyDocumentQuestions.slice()
-      if (f === null) {
-        emptyDuplicate[index] = false
-      } else {
-        emptyDuplicate[index] = true
-      }
-      setDocumentQuestions(duplicate)
-      setEmptyDocumentQuestions(emptyDuplicate)
+        const url = window.URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.setAttribute('download', 'document.pdf')
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+        */
+
+        console.log(duplicate)
+        duplicate[index].answer = f
+        const emptyDuplicate = emptyDocumentQuestions.slice()
+        if (f === null) {
+          emptyDuplicate[index] = false
+        } else {
+          emptyDuplicate[index] = true
+        }
+        setDocumentQuestions(duplicate)
+        setEmptyDocumentQuestions(emptyDuplicate)
+      } else throw new Error('File not found')
     }
   }
   const updateOther = (text: any, index: number): void => {
@@ -209,6 +226,28 @@ const InfoSubmissionPage = ({ applicantId }: PropTypes): JSX.Element => {
   }
 
   const closeModalHandler = (): void => setShowModal(false)
+
+  const downloadDocument = (index: number): void => {
+    const pdf = (documentQuestions[index].answer as any).data
+    console.log(pdf)
+
+    const buf = Buffer.from(pdf, 'base64')
+    console.log(buf.toString('base64'))
+
+    // const byteCharacters = base64ToArrayBuffer(pdf);
+    // console.log(byteCharacters)
+
+    const blob = new Blob([buf], { type: 'application/pdf' })
+    console.log(blob)
+
+    const url = window.URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.setAttribute('download', 'document.pdf')
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
 
   return (
     <div className={classes.bacoground}>
@@ -408,7 +447,7 @@ const InfoSubmissionPage = ({ applicantId }: PropTypes): JSX.Element => {
                     </Button>}
                     {formEditable && info.answer !== null && <InsertDriveFileIcon color="disabled" />}
                     {formEditable && <p className={classes.fileFontColor}>{'info.answer'}</p>}
-                    {!formEditable && info.answer !== null && <InsertDriveFileIcon color="primary" />}
+                    {!formEditable && info.answer !== null && <InsertDriveFileIcon color="primary" onClick={ () => downloadDocument(index) }/>}
                     {!formEditable && <p className={classes.displayFileColor}>{'info.answer'}</p>}
                   </div>
                 </div>

--- a/src/screens/InfoSubmission/InfoSubmissionPage.tsx
+++ b/src/screens/InfoSubmission/InfoSubmissionPage.tsx
@@ -109,15 +109,23 @@ const InfoSubmissionPage = ({ applicantId }: PropTypes): JSX.Element => {
   }
   const updateDocument = (file: any, index: number): void => {
     const duplicate = documentQuestions.slice()
-    duplicate[index].answer = file.target.files[0]
-    const emptyDuplicate = emptyDocumentQuestions.slice()
-    if (file.target.value === null) {
-      emptyDuplicate[index] = false
-    } else {
-      emptyDuplicate[index] = true
+    console.log(file.target.files[0])
+
+    const reader = new FileReader()
+    reader.readAsDataURL(file.target.files[0])
+    reader.onload = () => {
+      const f = reader.result as Buffer
+
+      duplicate[index].answer = f
+      const emptyDuplicate = emptyDocumentQuestions.slice()
+      if (f === null) {
+        emptyDuplicate[index] = false
+      } else {
+        emptyDuplicate[index] = true
+      }
+      setDocumentQuestions(duplicate)
+      setEmptyDocumentQuestions(emptyDuplicate)
     }
-    setDocumentQuestions(duplicate)
-    setEmptyDocumentQuestions(emptyDuplicate)
   }
   const updateOther = (text: any, index: number): void => {
     const duplicate = otherQuestions.slice()
@@ -399,9 +407,9 @@ const InfoSubmissionPage = ({ applicantId }: PropTypes): JSX.Element => {
                       }}/>
                     </Button>}
                     {formEditable && info.answer !== null && <InsertDriveFileIcon color="disabled" />}
-                    {formEditable && <p className={classes.fileFontColor}>{info.answer}</p>}
+                    {formEditable && <p className={classes.fileFontColor}>{'info.answer'}</p>}
                     {!formEditable && info.answer !== null && <InsertDriveFileIcon color="primary" />}
-                    {!formEditable && <p className={classes.displayFileColor}>{info.answer}</p>}
+                    {!formEditable && <p className={classes.displayFileColor}>{'info.answer'}</p>}
                   </div>
                 </div>
               ))}

--- a/src/screens/InfoSubmission/InfoSubmissionPage.tsx
+++ b/src/screens/InfoSubmission/InfoSubmissionPage.tsx
@@ -11,6 +11,7 @@ import { Edit } from '@mui/icons-material'
 import Stack from '@mui/material/Stack'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import CancelIcon from '@mui/icons-material/Cancel'
+import Link from '@mui/material/Link'
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked'
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile'
 import { getClient, changeStatus } from '../../actions/Client'
@@ -429,7 +430,7 @@ const InfoSubmissionPage = ({ applicantId }: PropTypes): JSX.Element => {
             <div className={classes.documentBody}>
               {documentQuestions?.map((info, index) => (
                 <div className={classes.documentSubmission}>
-                <FormLabel style={{ fontWeight: 'bold' }} error={info.answer === null} htmlFor="infoAns">{info.question.title}</FormLabel>
+                <FormLabel style={{ fontWeight: 'bold' }} error={(info.answer as any).data.length === 0} htmlFor="infoAns">{info.question.title}</FormLabel>
                   <p style = {{ fontWeight: 'lighter' }}>{info.question.description}</p>
                   <div className={classes.submissionStack}>
                   {formEditable && <Button
@@ -445,10 +446,12 @@ const InfoSubmissionPage = ({ applicantId }: PropTypes): JSX.Element => {
                         updateDocument(e, index)
                       }}/>
                     </Button>}
-                    {formEditable && info.answer !== null && <InsertDriveFileIcon color="disabled" />}
-                    {formEditable && <p className={classes.fileFontColor}>{'info.answer'}</p>}
-                    {!formEditable && info.answer !== null && <InsertDriveFileIcon color="primary" onClick={ () => downloadDocument(index) }/>}
-                    {!formEditable && <p className={classes.displayFileColor}>{'info.answer'}</p>}
+
+                    {(info.answer as any).data.length !== 0 &&
+                      <InsertDriveFileIcon color="primary" onClick={ () => downloadDocument(index) }/>
+                    }
+
+                    <Link disabled={(info.answer as any).data.length === 0} component="button" className={classes.fileFontColor} onClick={ () => downloadDocument(index) }>{info.question.title}</Link>
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
Implements ability for users to upload documents and download those documents.
Note that this only works for small files as of now.

Currently, documents are stored as raw binary data - issues around next.js api limits and MongoDB storage capabilities.
For the future, move to storage bucket solution.

Implements #93 
Changes documentQA types
